### PR TITLE
Add support for functional dependency injection inside resolvers

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const getAppConfig = () => {
 // @param  {String|Array} 	options.ignore      Defines globbing patterns to ignore certain files or folders (e.g., ignore: ['**/productquery.js', '**/variantquery.js'], ignore: ignore: 'variant/*').
 // @param  {String} 		options.mode 		Defines whether the GraphQL resolvers are defined using standard javascript files, typescript files or a custom globbing pattern. 
 // 												Valid values: 'js', 'ts', '<globbing pattern>'	
+// @param  {any}    		options.context    	Passed in as the argument to resolvers exported as functions (e.g. { context: { databaseConnection } }).
 // @return {Object}         result
 // @return {String}         result.schema 		Aggregated string made of all the schemas defined in the various .graphql files under folder located at 'schemaFolderPath'
 // @return {Object}         result.resolve   	Aggregated object made of all the resolvers defined in the various .graphql files under folder located at 'schemaFolderPath'
@@ -73,8 +74,10 @@ const glue = (schemaFolderPath, options={}) => {
 		const q = query && typeof(query) == 'string' ? (a.query + '\n' + query).trim() : a.query
 		const m = mutation && typeof(mutation) == 'string' ? (a.mutation + '\n' + mutation).trim() : a.mutation
 		const sub = subscription && typeof(subscription) == 'string' ? (a.subscription + '\n' + subscription).trim() : a.subscription
-		for(let key in resolver) 
-			a.resolver[key] = Object.assign((a.resolver[key] || {}), (resolver[key] || {}))
+		const expandedResolver = typeof(resolver) == 'function' ? resolver(options.context) : resolver
+
+		for(let key in expandedResolver)
+			a.resolver[key] = Object.assign((a.resolver[key] || {}), (expandedResolver[key] || {}))
 		return { schema: s, resolver: a.resolver, query: q, mutation: m, subscription: sub } 
 	}, { schema: '', resolver: {}, query: 'type Query {', mutation: 'type Mutation {', subscription: 'type Subscription {' })
 

--- a/test/graphql/mock_07/core/schema.graphql
+++ b/test/graphql/mock_07/core/schema.graphql
@@ -1,0 +1,4 @@
+# This is a message
+type UpdateMessage {
+	message: String!
+}

--- a/test/graphql/mock_07/product/productquery.graphql
+++ b/test/graphql/mock_07/product/productquery.graphql
@@ -1,0 +1,7 @@
+type Query {
+  # ### GET products
+  #
+  # _Arguments_
+  # - **id**: Product's id (optional)
+  products(id: Int): [Product]
+}

--- a/test/graphql/mock_07/product/resolver.js
+++ b/test/graphql/mock_07/product/resolver.js
@@ -1,0 +1,22 @@
+exports.resolver = context => {
+	return {
+		Query: {
+			products(root, { id }) {
+				const { GetProducts } = context
+				return GetProducts(id)
+			}
+		},
+
+		Mutation: {
+			productUpdateName(root, { id, name }) {
+				return { message: `Updating product (id ${id}) with name ${name} successful` }
+			}
+		},
+
+		Subscription: {
+			productNameChanged(root, { id }) {
+				return { id: id, name: 'some name' }
+			}
+		}
+	}
+}

--- a/test/graphql/mock_07/product/schema.js
+++ b/test/graphql/mock_07/product/schema.js
@@ -1,0 +1,29 @@
+exports.schema = `
+type Product {
+  id: ID!
+  name: String!
+  shortDescription: String
+}
+
+type ProductNameChangedMsg {
+  id: ID!
+  name: String
+}
+`
+// Notice that we have omitted to wrap the above with 'type Query { }'
+exports.mutation =`
+  # ### Update a product's name
+  #
+  # _Arguments_
+  # - **id**: Product's id
+  # - **name**: New product's name
+  productUpdateName(id: Int, name: String): UpdateMessage
+`
+
+exports.subscription =`
+  # ### Listen for product's name changes
+  #
+  # _Arguments_
+  # - **id**: Product's id
+  productNameChanged(id: Int): ProductNameChangedMsg
+`

--- a/test/graphql/mock_07/variant/resolver.js
+++ b/test/graphql/mock_07/variant/resolver.js
@@ -1,0 +1,25 @@
+const variantMocks = [{ id: 1, name: 'Variant A', shortDescription: 'First variant.' }, { id: 2, name: 'Variant B', shortDescription: 'Second variant.' }]
+
+exports.resolver = {
+	Query: {
+		variants(root, { id }) {
+			const results = id ? variantMocks.filter(p => p.id == id) : variantMocks
+			if (results)
+				return results
+			else
+				throw new Error(`Variant with id ${id} does not exist.`)
+		}
+	},
+
+	Mutation: {
+		variantUpdateName(root, { id, name }) {
+			return { message: `Updating variant (id ${id}) with name ${name} successful` }
+		}
+	},
+
+	Subscription: {
+		variantNameChanged(root, { id }) {
+			return { id: id, name: 'some name' }
+		}
+	}
+}

--- a/test/graphql/mock_07/variant/schema.graphql
+++ b/test/graphql/mock_07/variant/schema.graphql
@@ -1,0 +1,38 @@
+# This is 
+# a
+# Variant
+type Variant {
+  id: ID!
+  name: String!
+  shortDescription: String
+}
+
+type VariantNameChangedMsg {
+	id: ID!
+	name: String
+}
+
+type Query {
+  # ### GET products
+  #
+  # _Arguments_
+  # - **id**: Product's id (optional)
+  variants(id: Int): [Variant]
+}
+
+type Mutation {
+  # ### Update a variant's name
+  #
+  # _Arguments_
+  # - **id**: Variant's id
+  # - **name**: New variant's name
+  variantUpdateName(id: Int, name: String): UpdateMessage
+}
+
+type Subscription {
+  # ### Listen for variant's name changes
+  #
+  # _Arguments_
+  # - **id**: Variant's id
+  variantNameChanged(id: Int): VariantNameChangedMsg
+}

--- a/test/graphql/mock_07/variant/variantquery.js
+++ b/test/graphql/mock_07/variant/variantquery.js
@@ -1,0 +1,7 @@
+exports.query = `
+  # ### GET variants
+  #
+  # _Arguments_
+  # - **id**: Variant's id (optional)
+  variants(id: Int): [Variant]
+`

--- a/test/index.js
+++ b/test/index.js
@@ -503,4 +503,29 @@ describe('glue', () => {
 		assert.isOk(resolver.Query.products, 'resolver.Query.products should exist.')
 		assert.isOk(!resolver.Query.variants, 'resolver.Query.variants should not exist.')
 	})
+	it('#8 CONTEXT SUPPORT - Should support resolvers that are functions by passing in options.context.', () => {
+		const GetProducts = id => ([{ id: id, name: 'Special product', shortDescription: 'My special product mock.' }])
+		const { schema, resolver } = glue('./test/graphql/mock_07', { context: { GetProducts } })
+		
+		assert.isOk(resolver, 'resolver should exist.')
+		assert.isOk(resolver.Query, 'resolver.Query should exist.')
+		assert.isOk(resolver.Query.products, 'resolver.Query.products should exist.')
+		assert.isOk(resolver.Query.variants, 'resolver.Query.variants should exist.')
+		assert.isOk(resolver.Mutation, 'resolver.Mutation should exist.')
+		assert.isOk(resolver.Mutation.productUpdateName, 'resolver.Mutation.productUpdateName should exist.')
+		assert.isOk(resolver.Mutation.variantUpdateName, 'resolver.Mutation.variantUpdateName should exist.')
+		assert.isOk(resolver.Subscription, 'resolver.Subscription should exist.')
+		assert.isOk(resolver.Subscription.productNameChanged, 'resolver.Subscription.productNameChanged should exist.')
+		assert.isOk(resolver.Subscription.variantNameChanged, 'resolver.Subscription.variantNameChanged should exist.')
+
+		let createExecutableSchema = () => makeExecutableSchema({
+			typeDefs: schema,
+			resolvers: resolver
+		})
+
+		createExecutableSchema()
+		assert.doesNotThrow(createExecutableSchema, Error, 'createExecutableSchema should have succeeded.')
+
+		assert.deepEqual(resolver.Query.products(null, { id: 1 }), [{ id: 1, name: 'Special product', shortDescription: 'My special product mock.' }], 'resolver.Query.products should be able to use the context')
+	})
 })


### PR DESCRIPTION
First off, I want to thank you for an awesome library! I recently started a greenfield project using GraphQL, and this library has been an awesome addition.

To facilitate functional dependency injection, I'm proposing to allow resolvers to be exported as functions with a single `context` argument. When glueing everything together using `glue('src/graphql', options)`, `options.context` gets passed into each resolver's `context` argument. `context` is best used as a hash of dependencies. This pattern facilitates the unit testing of resolvers by allowing dependencies to be easily mocked.
 
Basic example passing in raw data:
 
```js
// app.js
const productMocks = [
  { id: 1, name: 'Product 1', shortDescription: 'Product #1.' }, 
  { id: 2, name: 'Product 2', shortDescription: 'Product #2.' }
]
const { schema, resolver } = glue('src/graphql', { context: { productMocks } })
    
// src/graphql/product/resolver.js
exports.resolver = context => {
  return {
    Query: {
      products(root, { id }) {
        const { productMocks } = context
        const results = id ? productMocks.filter(p => p.id == id) : productMocks
        return results ||  null
      }
    }
  }
}
```
 
Advanced example passing in a curried function that encapsulates the shared database connection. This makes testing resolvers incredibly easy:
 
```js
// app.js
const sharedDatabaseConnection = ...
const GetProducts = ProductsService.GetProducts({ db: sharedDatabaseConnection }) // curried function so we don't have to pass the shared database connection around
const { schema, resolver } = glue('src/graphql', { context: { GetProducts } })
 
// src/graphql/product/resolver.js
exports.resolver = context => {
  return {
    Query: {
      products(root, { id }) {
        const { GetProducts } = context
        return GetProducts(id) // resolver has no direct reference to the shared database connection
      }
    }
  }
}
 
// test/graphql/product/resolver-test.js
it('returns the correct products for a given id', () => {
  const GetProducts = id => ([{ id: id, name: 'Special product', shortDescription: 'My special product mock.' }])
  const { resolver } = glue('src/graphql', { context: { GetProducts } })
  assert.deepEqual(resolver.Query.products(null, { id: 1 }), [{ id: 1, name: 'Special product', shortDescription: 'My special product mock.' }])
})
```

Thanks!